### PR TITLE
Add EDA notebooks for MIMIC and eICU datasets

### DIFF
--- a/code/eicu/eda_eicu.ipynb
+++ b/code/eicu/eda_eicu.ipynb
@@ -1,0 +1,456 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2884ce9a",
+   "metadata": {},
+   "source": [
+    "# eICU Dataset Exploratory Analysis\n",
+    "\n",
+    "This notebook loads the `eICU_data.csv.gz` file and provides a brief overview of its structure and key clinical features.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "be179e25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:57:49.413448Z",
+     "iopub.status.busy": "2025-08-03T15:57:49.413265Z",
+     "iopub.status.idle": "2025-08-03T15:57:49.870647Z",
+     "shell.execute_reply": "2025-08-03T15:57:49.869911Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pathlib\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3af48156",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:57:49.873426Z",
+     "iopub.status.busy": "2025-08-03T15:57:49.873131Z",
+     "iopub.status.idle": "2025-08-03T15:57:56.200813Z",
+     "shell.execute_reply": "2025-08-03T15:57:56.200092Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1206142, 28)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hospital_id</th>\n",
+       "      <th>patient_id</th>\n",
+       "      <th>hospitalization_id</th>\n",
+       "      <th>recorded_dttm</th>\n",
+       "      <th>ARDS_onset_time</th>\n",
+       "      <th>time_from_ARDS_onset</th>\n",
+       "      <th>APACHE</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>age_at_admission</th>\n",
+       "      <th>ethinicity</th>\n",
+       "      <th>...</th>\n",
+       "      <th>height_cm</th>\n",
+       "      <th>weight_kg</th>\n",
+       "      <th>nmb_used</th>\n",
+       "      <th>cisatracurium_dose</th>\n",
+       "      <th>vecuronium_dose</th>\n",
+       "      <th>rocuronium_dose</th>\n",
+       "      <th>atracurium_dose</th>\n",
+       "      <th>pancuronium_dose</th>\n",
+       "      <th>prone_flag</th>\n",
+       "      <th>new_tracheostomy</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2000623</td>\n",
+       "      <td>11227959.0</td>\n",
+       "      <td>9462077</td>\n",
+       "      <td>2023-01-01 03:13:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>193.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>88</td>\n",
+       "      <td>Caucasian</td>\n",
+       "      <td>...</td>\n",
+       "      <td>159.0</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2000623</td>\n",
+       "      <td>11227959.0</td>\n",
+       "      <td>9462077</td>\n",
+       "      <td>2023-01-01 06:10:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>370.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>88</td>\n",
+       "      <td>Caucasian</td>\n",
+       "      <td>...</td>\n",
+       "      <td>159.0</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2000623</td>\n",
+       "      <td>11227959.0</td>\n",
+       "      <td>9462077</td>\n",
+       "      <td>2023-01-01 10:03:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>603.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>88</td>\n",
+       "      <td>Caucasian</td>\n",
+       "      <td>...</td>\n",
+       "      <td>159.0</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2000623</td>\n",
+       "      <td>11227959.0</td>\n",
+       "      <td>9462077</td>\n",
+       "      <td>2023-01-01 11:13:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>673.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>88</td>\n",
+       "      <td>Caucasian</td>\n",
+       "      <td>...</td>\n",
+       "      <td>159.0</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2000623</td>\n",
+       "      <td>11227959.0</td>\n",
+       "      <td>9462077</td>\n",
+       "      <td>2023-01-01 11:21:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>681.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>88</td>\n",
+       "      <td>Caucasian</td>\n",
+       "      <td>...</td>\n",
+       "      <td>159.0</td>\n",
+       "      <td>52.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 28 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   hospital_id  patient_id  hospitalization_id        recorded_dttm  \\\n",
+       "0      2000623  11227959.0             9462077  2023-01-01 03:13:00   \n",
+       "1      2000623  11227959.0             9462077  2023-01-01 06:10:00   \n",
+       "2      2000623  11227959.0             9462077  2023-01-01 10:03:00   \n",
+       "3      2000623  11227959.0             9462077  2023-01-01 11:13:00   \n",
+       "4      2000623  11227959.0             9462077  2023-01-01 11:21:00   \n",
+       "\n",
+       "   ARDS_onset_time  time_from_ARDS_onset  APACHE     sex  age_at_admission  \\\n",
+       "0                0                 193.0     NaN  Female                88   \n",
+       "1                0                 370.0     NaN  Female                88   \n",
+       "2                0                 603.0     NaN  Female                88   \n",
+       "3                0                 673.0     NaN  Female                88   \n",
+       "4                0                 681.0     NaN  Female                88   \n",
+       "\n",
+       "  ethinicity  ... height_cm weight_kg  nmb_used  cisatracurium_dose  \\\n",
+       "0  Caucasian  ...     159.0      52.0       0.0                 0.0   \n",
+       "1  Caucasian  ...     159.0      52.0       0.0                 0.0   \n",
+       "2  Caucasian  ...     159.0      52.0       0.0                 0.0   \n",
+       "3  Caucasian  ...     159.0      52.0       0.0                 0.0   \n",
+       "4  Caucasian  ...     159.0      52.0       0.0                 0.0   \n",
+       "\n",
+       "   vecuronium_dose  rocuronium_dose  atracurium_dose  pancuronium_dose  \\\n",
+       "0              0.0              0.0              0.0               0.0   \n",
+       "1              0.0              0.0              0.0               0.0   \n",
+       "2              0.0              0.0              0.0               0.0   \n",
+       "3              0.0              0.0              0.0               0.0   \n",
+       "4              0.0              0.0              0.0               0.0   \n",
+       "\n",
+       "   prone_flag  new_tracheostomy  \n",
+       "0           0                 0  \n",
+       "1           0                 0  \n",
+       "2           0                 0  \n",
+       "3           0                 0  \n",
+       "4           0                 0  \n",
+       "\n",
+       "[5 rows x 28 columns]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_path = pathlib.Path('../../data/raw/eICU_data.csv.gz')\n",
+    "# Load compressed CSV\n",
+    "data = pd.read_csv(data_path)\n",
+    "print(data.shape)\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb047324",
+   "metadata": {},
+   "source": [
+    "## Column completeness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f77cea4b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:57:56.202784Z",
+     "iopub.status.busy": "2025-08-03T15:57:56.202578Z",
+     "iopub.status.idle": "2025-08-03T15:57:56.480423Z",
+     "shell.execute_reply": "2025-08-03T15:57:56.479844Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pao2                    9.388505e-01\n",
+       "lmp_set                 9.345624e-01\n",
+       "spo2                    7.272245e-01\n",
+       "peep                    6.625820e-01\n",
+       "fio2_set                2.667140e-01\n",
+       "APACHE                  1.919641e-01\n",
+       "respiratory_device      1.072187e-01\n",
+       "ethinicity              8.230374e-03\n",
+       "height_cm               3.322163e-03\n",
+       "weight_kg               1.026413e-03\n",
+       "disposition_category    8.290898e-07\n",
+       "recorded_dttm           0.000000e+00\n",
+       "age_at_admission        0.000000e+00\n",
+       "ARDS_onset_time         0.000000e+00\n",
+       "time_from_ARDS_onset    0.000000e+00\n",
+       "sex                     0.000000e+00\n",
+       "hospital_id             0.000000e+00\n",
+       "patient_id              0.000000e+00\n",
+       "hospitalization_id      0.000000e+00\n",
+       "ecmo_flag               0.000000e+00\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.isnull().mean().sort_values(ascending=False).head(20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "150b2fbb",
+   "metadata": {},
+   "source": [
+    "## Patient and hospitalisation counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "74fe003f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:57:56.482274Z",
+     "iopub.status.busy": "2025-08-03T15:57:56.482090Z",
+     "iopub.status.idle": "2025-08-03T15:57:56.503007Z",
+     "shell.execute_reply": "2025-08-03T15:57:56.502480Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'unique_patients': 16269, 'unique_hospitalizations': 15498}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_patients = data['patient_id'].nunique()\n",
+    "n_hosp = data['hospitalization_id'].nunique()\n",
+    "{'unique_patients': n_patients, 'unique_hospitalizations': n_hosp}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4896aed",
+   "metadata": {},
+   "source": [
+    "## Proning and outcomes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b6242e63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:57:56.504948Z",
+     "iopub.status.busy": "2025-08-03T15:57:56.504778Z",
+     "iopub.status.idle": "2025-08-03T15:57:56.525275Z",
+     "shell.execute_reply": "2025-08-03T15:57:56.524710Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "prone_flag\n",
+       "0    14660\n",
+       "1      838\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proning = data.groupby('hospitalization_id')['prone_flag'].max().value_counts()\n",
+    "proning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "832260b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:57:56.527321Z",
+     "iopub.status.busy": "2025-08-03T15:57:56.527149Z",
+     "iopub.status.idle": "2025-08-03T15:57:56.596951Z",
+     "shell.execute_reply": "2025-08-03T15:57:56.596349Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "disposition_category\n",
+       "Alive      886625\n",
+       "Expired    319516\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outcomes = data['disposition_category'].value_counts()\n",
+    "outcomes.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/code/mimic/eda_mimic.ipynb
+++ b/code/mimic/eda_mimic.ipynb
@@ -1,0 +1,657 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ca896992",
+   "metadata": {},
+   "source": [
+    "# MIMIC-IV Dataset Exploratory Analysis\n",
+    "\n",
+    "This notebook inspects the pre-computed MIMIC-IV ARDS datasets contained in the `static_analysis_table_mimic(1).parquet` and `time_series_analysis_table_mimic(1).parquet` files.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "32caad0d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:03.855151Z",
+     "iopub.status.busy": "2025-08-03T15:58:03.854968Z",
+     "iopub.status.idle": "2025-08-03T15:58:04.304949Z",
+     "shell.execute_reply": "2025-08-03T15:58:04.304289Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pyarrow.parquet as pq\n",
+    "import pathlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "52c75b41",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:04.307684Z",
+     "iopub.status.busy": "2025-08-03T15:58:04.307398Z",
+     "iopub.status.idle": "2025-08-03T15:58:04.385439Z",
+     "shell.execute_reply": "2025-08-03T15:58:04.384887Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(90481, 14)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "static_path = pathlib.Path('../../data/raw/static_analysis_table_mimic(1).parquet')\n",
+    "static = pq.read_table(static_path).to_pandas()\n",
+    "static.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "95bec33b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:04.387421Z",
+     "iopub.status.busy": "2025-08-03T15:58:04.387233Z",
+     "iopub.status.idle": "2025-08-03T15:58:04.402437Z",
+     "shell.execute_reply": "2025-08-03T15:58:04.401826Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hospital_id</th>\n",
+       "      <th>patient_id</th>\n",
+       "      <th>hospitalization_id</th>\n",
+       "      <th>admission_datetime</th>\n",
+       "      <th>discharge_datetime</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>age_at_admission</th>\n",
+       "      <th>disposition_category</th>\n",
+       "      <th>hospital_admit_source</th>\n",
+       "      <th>mortality</th>\n",
+       "      <th>icu_los_days</th>\n",
+       "      <th>hospital_los_days</th>\n",
+       "      <th>ventilator_free_days_28</th>\n",
+       "      <th>race</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10001884</td>\n",
+       "      <td>26184834</td>\n",
+       "      <td>2131-01-07 20:39:00</td>\n",
+       "      <td>2131-01-20 05:15:00</td>\n",
+       "      <td>F</td>\n",
+       "      <td>77</td>\n",
+       "      <td>Expired</td>\n",
+       "      <td>EMERGENCY ROOM</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.171817</td>\n",
+       "      <td>12.358333</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Black</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10001884</td>\n",
+       "      <td>26184834</td>\n",
+       "      <td>2131-01-07 20:39:00</td>\n",
+       "      <td>2131-01-20 05:15:00</td>\n",
+       "      <td>F</td>\n",
+       "      <td>77</td>\n",
+       "      <td>Expired</td>\n",
+       "      <td>EMERGENCY ROOM</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.171817</td>\n",
+       "      <td>12.358333</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Black</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10001884</td>\n",
+       "      <td>26184834</td>\n",
+       "      <td>2131-01-07 20:39:00</td>\n",
+       "      <td>2131-01-20 05:15:00</td>\n",
+       "      <td>F</td>\n",
+       "      <td>77</td>\n",
+       "      <td>Expired</td>\n",
+       "      <td>EMERGENCY ROOM</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.171817</td>\n",
+       "      <td>12.358333</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Black</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10001884</td>\n",
+       "      <td>26184834</td>\n",
+       "      <td>2131-01-07 20:39:00</td>\n",
+       "      <td>2131-01-20 05:15:00</td>\n",
+       "      <td>F</td>\n",
+       "      <td>77</td>\n",
+       "      <td>Expired</td>\n",
+       "      <td>EMERGENCY ROOM</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.171817</td>\n",
+       "      <td>12.358333</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Black</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10001884</td>\n",
+       "      <td>26184834</td>\n",
+       "      <td>2131-01-07 20:39:00</td>\n",
+       "      <td>2131-01-20 05:15:00</td>\n",
+       "      <td>F</td>\n",
+       "      <td>77</td>\n",
+       "      <td>Expired</td>\n",
+       "      <td>EMERGENCY ROOM</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9.171817</td>\n",
+       "      <td>12.358333</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Black</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  hospital_id  patient_id  hospitalization_id  admission_datetime  \\\n",
+       "0       BIDMC    10001884            26184834 2131-01-07 20:39:00   \n",
+       "1       BIDMC    10001884            26184834 2131-01-07 20:39:00   \n",
+       "2       BIDMC    10001884            26184834 2131-01-07 20:39:00   \n",
+       "3       BIDMC    10001884            26184834 2131-01-07 20:39:00   \n",
+       "4       BIDMC    10001884            26184834 2131-01-07 20:39:00   \n",
+       "\n",
+       "   discharge_datetime sex  age_at_admission disposition_category  \\\n",
+       "0 2131-01-20 05:15:00   F                77              Expired   \n",
+       "1 2131-01-20 05:15:00   F                77              Expired   \n",
+       "2 2131-01-20 05:15:00   F                77              Expired   \n",
+       "3 2131-01-20 05:15:00   F                77              Expired   \n",
+       "4 2131-01-20 05:15:00   F                77              Expired   \n",
+       "\n",
+       "  hospital_admit_source  mortality  icu_los_days  hospital_los_days  \\\n",
+       "0        EMERGENCY ROOM          1      9.171817          12.358333   \n",
+       "1        EMERGENCY ROOM          1      9.171817          12.358333   \n",
+       "2        EMERGENCY ROOM          1      9.171817          12.358333   \n",
+       "3        EMERGENCY ROOM          1      9.171817          12.358333   \n",
+       "4        EMERGENCY ROOM          1      9.171817          12.358333   \n",
+       "\n",
+       "   ventilator_free_days_28   race  \n",
+       "0                      0.0  Black  \n",
+       "1                      0.0  Black  \n",
+       "2                      0.0  Black  \n",
+       "3                      0.0  Black  \n",
+       "4                      0.0  Black  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "static.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3d1dd3f",
+   "metadata": {},
+   "source": [
+    "## Static table completeness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "21e9a9bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:04.404311Z",
+     "iopub.status.busy": "2025-08-03T15:58:04.404122Z",
+     "iopub.status.idle": "2025-08-03T15:58:04.432815Z",
+     "shell.execute_reply": "2025-08-03T15:58:04.432286Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "hospital_id                0.0\n",
+       "patient_id                 0.0\n",
+       "hospitalization_id         0.0\n",
+       "admission_datetime         0.0\n",
+       "discharge_datetime         0.0\n",
+       "sex                        0.0\n",
+       "age_at_admission           0.0\n",
+       "disposition_category       0.0\n",
+       "hospital_admit_source      0.0\n",
+       "mortality                  0.0\n",
+       "icu_los_days               0.0\n",
+       "hospital_los_days          0.0\n",
+       "ventilator_free_days_28    0.0\n",
+       "race                       0.0\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "static.isnull().mean().sort_values(ascending=False).head(20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea7e98ce",
+   "metadata": {},
+   "source": [
+    "## Time-series data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fea676fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:04.434612Z",
+     "iopub.status.busy": "2025-08-03T15:58:04.434438Z",
+     "iopub.status.idle": "2025-08-03T15:58:05.027585Z",
+     "shell.execute_reply": "2025-08-03T15:58:05.027204Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1007358, 25)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "time_path = pathlib.Path('../../data/raw/time_series_analysis_table_mimic(1).parquet')\n",
+    "time = pq.read_table(time_path).to_pandas()\n",
+    "time.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bb52c938",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:05.029483Z",
+     "iopub.status.busy": "2025-08-03T15:58:05.029196Z",
+     "iopub.status.idle": "2025-08-03T15:58:05.044074Z",
+     "shell.execute_reply": "2025-08-03T15:58:05.043564Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hospital_id</th>\n",
+       "      <th>patient_id</th>\n",
+       "      <th>hospitalization_id</th>\n",
+       "      <th>recorded_dttm</th>\n",
+       "      <th>icu_in_time</th>\n",
+       "      <th>icu_type</th>\n",
+       "      <th>ARDS_onset_dttm</th>\n",
+       "      <th>time_from_ARDS_onset</th>\n",
+       "      <th>respiratory_device</th>\n",
+       "      <th>ecmo_flag</th>\n",
+       "      <th>...</th>\n",
+       "      <th>height_cm</th>\n",
+       "      <th>weight_kg</th>\n",
+       "      <th>cisatracurium_dose</th>\n",
+       "      <th>vecuronium_dose</th>\n",
+       "      <th>rocuronium_dose</th>\n",
+       "      <th>atracurium_dose</th>\n",
+       "      <th>pancuronium_dose</th>\n",
+       "      <th>position</th>\n",
+       "      <th>new_tracheostomy</th>\n",
+       "      <th>prone_flag</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10004720</td>\n",
+       "      <td>22081550</td>\n",
+       "      <td>2186-11-12 18:02:00</td>\n",
+       "      <td>2186-11-12 19:55:00</td>\n",
+       "      <td>MICU</td>\n",
+       "      <td>2186-11-12 20:00:00</td>\n",
+       "      <td>-1.966667</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>...</td>\n",
+       "      <td>183</td>\n",
+       "      <td>70</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10004720</td>\n",
+       "      <td>22081550</td>\n",
+       "      <td>2186-11-12 20:00:00</td>\n",
+       "      <td>2186-11-12 19:55:00</td>\n",
+       "      <td>MICU</td>\n",
+       "      <td>2186-11-12 20:00:00</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>Endotracheal tube</td>\n",
+       "      <td>None</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>70</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Left Side</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10004720</td>\n",
+       "      <td>22081550</td>\n",
+       "      <td>2186-11-12 20:06:00</td>\n",
+       "      <td>2186-11-12 19:55:00</td>\n",
+       "      <td>MICU</td>\n",
+       "      <td>2186-11-12 20:00:00</td>\n",
+       "      <td>0.100000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10004720</td>\n",
+       "      <td>22081550</td>\n",
+       "      <td>2186-11-12 21:00:00</td>\n",
+       "      <td>2186-11-12 19:55:00</td>\n",
+       "      <td>MICU</td>\n",
+       "      <td>2186-11-12 20:00:00</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>BIDMC</td>\n",
+       "      <td>10004720</td>\n",
+       "      <td>22081550</td>\n",
+       "      <td>2186-11-12 22:00:00</td>\n",
+       "      <td>2186-11-12 19:55:00</td>\n",
+       "      <td>MICU</td>\n",
+       "      <td>2186-11-12 20:00:00</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>Right Side</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 25 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  hospital_id  patient_id  hospitalization_id       recorded_dttm  \\\n",
+       "0       BIDMC    10004720            22081550 2186-11-12 18:02:00   \n",
+       "1       BIDMC    10004720            22081550 2186-11-12 20:00:00   \n",
+       "2       BIDMC    10004720            22081550 2186-11-12 20:06:00   \n",
+       "3       BIDMC    10004720            22081550 2186-11-12 21:00:00   \n",
+       "4       BIDMC    10004720            22081550 2186-11-12 22:00:00   \n",
+       "\n",
+       "          icu_in_time icu_type     ARDS_onset_dttm  time_from_ARDS_onset  \\\n",
+       "0 2186-11-12 19:55:00     MICU 2186-11-12 20:00:00             -1.966667   \n",
+       "1 2186-11-12 19:55:00     MICU 2186-11-12 20:00:00              0.000000   \n",
+       "2 2186-11-12 19:55:00     MICU 2186-11-12 20:00:00              0.100000   \n",
+       "3 2186-11-12 19:55:00     MICU 2186-11-12 20:00:00              1.000000   \n",
+       "4 2186-11-12 19:55:00     MICU 2186-11-12 20:00:00              2.000000   \n",
+       "\n",
+       "  respiratory_device ecmo_flag  ... height_cm weight_kg  cisatracurium_dose  \\\n",
+       "0               None      None  ...       183        70                 NaN   \n",
+       "1  Endotracheal tube      None  ...      None        70                 NaN   \n",
+       "2               None      None  ...      None      None                 NaN   \n",
+       "3               None      None  ...      None      None                 NaN   \n",
+       "4               None      None  ...      None      None                 NaN   \n",
+       "\n",
+       "  vecuronium_dose rocuronium_dose atracurium_dose pancuronium_dose  \\\n",
+       "0             NaN             NaN             0.0              0.0   \n",
+       "1             NaN             NaN             0.0              0.0   \n",
+       "2             NaN             NaN             0.0              0.0   \n",
+       "3             NaN             NaN             0.0              0.0   \n",
+       "4             NaN             NaN             0.0              0.0   \n",
+       "\n",
+       "     position  new_tracheostomy  prone_flag  \n",
+       "0        None              None           0  \n",
+       "1   Left Side              None           0  \n",
+       "2        None              None           0  \n",
+       "3        None              None           0  \n",
+       "4  Right Side              None           0  \n",
+       "\n",
+       "[5 rows x 25 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "time.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f842b862",
+   "metadata": {},
+   "source": [
+    "## Proning prevalence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "811810fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:05.054464Z",
+     "iopub.status.busy": "2025-08-03T15:58:05.054136Z",
+     "iopub.status.idle": "2025-08-03T15:58:05.174003Z",
+     "shell.execute_reply": "2025-08-03T15:58:05.173581Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "prone_flag\n",
+       "0    4191\n",
+       "1     211\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proning = time.groupby('hospitalization_id')['prone_flag'].max().value_counts()\n",
+    "proning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c5c9db1",
+   "metadata": {},
+   "source": [
+    "## Mortality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9a984469",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-03T15:58:05.175777Z",
+     "iopub.status.busy": "2025-08-03T15:58:05.175611Z",
+     "iopub.status.idle": "2025-08-03T15:58:05.181337Z",
+     "shell.execute_reply": "2025-08-03T15:58:05.180823Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "mortality\n",
+       "0    80408\n",
+       "1    10073\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mortality = static['mortality'].value_counts()\n",
+    "mortality"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add exploratory data analysis notebook for eICU dataset covering structure, proning, and outcomes
- add exploratory notebook for pre-computed MIMIC ARDS tables including proning prevalence and mortality
- execute both notebooks to generate summary outputs

## Testing
- `jupyter nbconvert --to notebook --execute --inplace code/eicu/eda_eicu.ipynb`
- `jupyter nbconvert --to notebook --execute --inplace code/mimic/eda_mimic.ipynb`
- `pytest`


